### PR TITLE
Add simple Streamlit PDF translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# oma-pdf-translate
+# PDF Translation App
+
+This project provides a simple Streamlit application that translates the text in a PDF while trying to keep the original layout. It is intended for translating official documents where formatting matters.
+
+## Features
+- Upload a PDF file using the web interface.
+- Choose a source language (English, German, or French).
+- Choose a target language (Traditional Chinese or English).
+- Download the translated PDF once processing is complete.
+
+Translation quality depends on the translator backend. The included example uses `googletrans` for demonstration. For higher quality consider integrating the DeepL or OpenAI API.
+
+## Setup
+1. Install dependencies (Python 3.9+ recommended):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the Streamlit application:
+   ```bash
+   streamlit run main.py
+   ```
+
+## Custom Translator
+To use DeepL or GPT-4, modify `translate_text` in `main.py` to call the desired API. Example with DeepL:
+```python
+import deepl
+translator = deepl.Translator("YOUR_API_KEY")
+result = translator.translate_text(text, source_lang=src.upper(), target_lang=dest.upper())
+return result.text
+```
+
+## Limitations
+- Perfect layout preservation for complex PDFs is difficult. Some formatting loss may occur.
+- Googletrans may fail on large texts or with strict rate limits.
+
+This repository serves as a starting point for a production-ready solution.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,72 @@
+import io
+import streamlit as st
+import fitz  # PyMuPDF
+from googletrans import Translator
+
+
+def translate_text(text: str, translator: Translator, src: str, dest: str) -> str:
+    if not text.strip():
+        return text
+    try:
+        result = translator.translate(text, src=src, dest=dest)
+        return result.text
+    except Exception as e:
+        st.warning(f"Translation failed: {e}")
+        return text
+
+
+def translate_pdf(data: bytes, src_lang: str, tgt_lang: str) -> bytes:
+    """Translate PDF text while trying to preserve layout."""
+    doc = fitz.open(stream=data, filetype="pdf")
+    translator = Translator()
+
+    for page in doc:
+        text_page = page.get_text("dict")
+        for block in text_page.get("blocks", []):
+            for line in block.get("lines", []):
+                line_text = " ".join(span["text"] for span in line.get("spans", []))
+                if not line_text.strip():
+                    continue
+                translated = translate_text(line_text, translator, src_lang, tgt_lang)
+                bbox = fitz.Rect(line["bbox"])
+                page.add_redact_annot(bbox, fill=(1, 1, 1))
+                page.apply_redactions()
+                page.insert_text((bbox.x0, bbox.y1 - 2), translated, fontsize=12)
+
+    output = io.BytesIO()
+    doc.save(output)
+    return output.getvalue()
+
+
+LANG_OPTIONS = {
+    "English": "en",
+    "German": "de",
+    "French": "fr",
+}
+
+TARGET_OPTIONS = {
+    "Traditional Chinese": "zh-tw",
+    "English": "en",
+}
+
+st.title("PDF Translation App")
+
+uploaded_pdf = st.file_uploader("Upload PDF", type="pdf")
+
+col1, col2 = st.columns(2)
+with col1:
+    src_lang_label = st.selectbox("Source Language", list(LANG_OPTIONS.keys()))
+with col2:
+    tgt_lang_label = st.selectbox("Target Language", list(TARGET_OPTIONS.keys()))
+
+if st.button("Translate") and uploaded_pdf:
+    src_lang = LANG_OPTIONS[src_lang_label]
+    tgt_lang = TARGET_OPTIONS[tgt_lang_label]
+    with st.spinner("Translating..."):
+        result_bytes = translate_pdf(uploaded_pdf.read(), src_lang, tgt_lang)
+    st.download_button(
+        "Download translated PDF",
+        result_bytes,
+        file_name="translated.pdf",
+        mime="application/pdf",
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+PyMuPDF
+googletrans==4.0.0rc1


### PR DESCRIPTION
## Summary
- create Streamlit app (`main.py`) for uploading a PDF, translating its text and downloading a translated PDF while trying to keep layout
- document setup and usage in README
- add requirements file

## Testing
- `python3 -m compileall .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685dfdc313848322b288e8dba59f186b